### PR TITLE
add multiple timezones only if users from multiple timezones joined the game

### DIFF
--- a/vars.py
+++ b/vars.py
@@ -53,6 +53,12 @@ EMOJI = {
     "tiger": emojize(":tiger2:", use_aliases=True),
 }
 
+USER_TIMEZONES = {
+    'timuber': 'Europe/London',
+    'sduwnik': 'Europe/London',
+    'anchik12345': 'Europe/London'
+}
+
 # CS:GO nicknames
 CSGO_NICKNAMES = {
     "aman_utemuratov": "amanchik",


### PR DESCRIPTION
Experimental feature to display multiple time zones only if users from multiple timezones joined the game.

Currently implemented by checking if users from London joined the game.